### PR TITLE
fix: AppDelegate mm extension support

### DIFF
--- a/src_bin/install
+++ b/src_bin/install
@@ -168,9 +168,14 @@ const start = async () => {
 
     {
       console.log('3. AppDelegate.m 설정');
-      let adf = await readFile(path + `/ios/${name}/AppDelegate.m`);
-      if (adf.indexOf('WithKakaoSDK.h') < 0) {
-        adf = '#import "WithKakaoSDK.h"\n' + adf;
+      let adf;
+      let extension = 'm';
+
+      try {
+        adf = await readFile(path + `/ios/${name}/AppDelegate.m`);
+      } catch {
+        adf = await readFile(path + `/ios/${name}/AppDelegate.mm`);
+        extension = 'mm';
       }
 
       if (adf.indexOf('[WithKakaoSDK isKakaoTalkLoginUrl:url]') < 0) {


### PR DESCRIPTION
<img width="1521" alt="CleanShot 2022-07-17 at 02 49 04@2x" src="https://user-images.githubusercontent.com/49827449/179366427-df1c94ad-8353-470f-bf8e-559ace88abe8.png">

`0.69.0` 버전부터 AppDelegate.m 파일의 확장자가 mm으로 변경되었습니다.